### PR TITLE
Cursor current unit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,6 @@ project.lock.json
 .idea
 /lib/libspreadsdb/src/libspreadsdb/libspreads_lmdb.def
 /lib/libspreadsdb/src/libspreadsdb/libspreads_lmdb.lib
-
+.vscode
 
 !lib/runtimes/**/*.*


### PR DESCRIPTION
As promised - for issue #27.

So we set the cursor to the first record and then keep deleting. The test is `CursorCanTryGetWhenAllRecordsDeleted`.

Cheers