### PR TITLE
Allow creating single file databases using LMDBEnvironmentFlags.NoSubDir

### DIFF
--- a/src/Spreads.LMDB/LMDBEnvironment.cs
+++ b/src/Spreads.LMDB/LMDBEnvironment.cs
@@ -94,10 +94,7 @@ namespace Spreads.LMDB
             {
                 directory = System.IO.Path.GetDirectoryName(_directory);
             }
-            if(!System.IO.Directory.Exists(directory))
-            {
-                System.IO.Directory.CreateDirectory(directory);
-            }
+            System.IO.Directory.CreateDirectory(directory);
         }
 
         private LMDBEnvironment(string directory,


### PR DESCRIPTION
This makes it possible to create single file lmdb databases using MDB_NOSUBDIR.

It might be good to rename the "directory" parameters and variables to "path" but that changes the API.  